### PR TITLE
fix(*): restore the element style on the out animation

### DIFF
--- a/src/runOutAnimations.js
+++ b/src/runOutAnimations.js
@@ -16,7 +16,7 @@ export default (activeElements) => {
     }
 
     return functionToPromise(() => {
-      el.style.cssText = el.styleCache;
+      el.style.cssText = el.animationData.styleCache;
       el.style.visibility = 'visible';
       el.style.cssText += ` animation-duration:${el.animationData.outDuration}; -webkit-animation-duration:${el.animationData.outDuration};`;
 


### PR DESCRIPTION
**Type of Change**
<!-- What type of change does your code introduce? -->
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing or correcting existing tests
- [ ] chore: Changes to the build process or auxiliary tools and libraries such as documentation generation

**Describe Changes**
<!-- Describe your changes in detail, if applicable. -->
The element style wasn't being properly restored on the "out" animation since it wasn't using the `animationData.styleCache` (probably a typo).